### PR TITLE
Update angular-hovercard.js

### DIFF
--- a/dist/angular-hovercard.js
+++ b/dist/angular-hovercard.js
@@ -59,6 +59,9 @@ angular.module('yaru22.hovercard', ['yaru22.hovercard.tmpls']).directive('hoverc
           $scope.hoverCardStyle.right = '';
         }
       }  // if (placement)
+       $attrs.$observe('hoverTmplUrl', function (newval) {
+          $scope.hoverTmplUrl = newval;
+      });
     }  // link function
   };
 });


### PR DESCRIPTION
Fixed issue where the hover card would not display if the hover-tmpl-url was pass as a parameter.